### PR TITLE
Add support for CMakeTest tests and sections

### DIFF
--- a/cminx/documenter.py
+++ b/cminx/documenter.py
@@ -19,7 +19,7 @@ from .parser.CMakeParser import CMakeParser
 from .parser.CMakeListener import CMakeListener
 from .rstwriter import RSTWriter
 from .parser.aggregator import DocumentationAggregator
-from .parser.aggregator import FunctionDocumentation, MacroDocumentation, VariableDocumentation
+from .parser.aggregator import FunctionDocumentation, MacroDocumentation, VariableDocumentation, TestDocumentation, SectionDocumentation
 
 
 
@@ -86,6 +86,10 @@ class Documenter(object):
                 self.process_macro_doc(doc)
             elif isinstance(doc, VariableDocumentation):
                 self.process_variable_doc(doc)
+            elif isinstance(doc, TestDocumentation):
+                self.process_test_doc(doc)
+            elif isinstance(doc, SectionDocumentation):
+                self.process_section_doc(doc)
 
 
     def process_function_doc(self, doc: FunctionDocumentation):
@@ -110,6 +114,32 @@ class Documenter(object):
 
         d = self.writer.directive("function", f"{doc.macro}({' '.join(doc.params)})")
         warning = d.directive("warning", "This is a macro, and so does not introduce a new scope.")
+        d.text(doc.doc)
+
+    def process_test_doc(self, doc):
+        """
+        TestDocumentation processor. Generates the RST "function" directive containing
+        a "warning" directive explaining that it is a test.
+
+        :param doc: Documentation for the test
+        :type doc: TestDocumentation
+        """
+
+        d = self.writer.directive("function", f"{doc.name}({'EXPECTFAIL' if doc.expect_fail else ''})")
+        warning = d.directive("warning", "This is a CMakeTest test definition, do not call this manually.")
+        d.text(doc.doc)
+
+    def process_section_doc(self, doc):
+        """
+        SectionDocumentation processor. Generates the RST "function" directive containing
+        a "warning" directive explaining that it is a test.
+
+        :param doc: Documentation for the test
+        :type doc: SectionDocumentation
+        """
+
+        d = self.writer.directive("function", f"{doc.name}({'EXPECTFAIL' if doc.expect_fail else ''})")
+        warning = d.directive("warning", "This is a CMakeTest section definition, do not call this manually.")
         d.text(doc.doc)
 
     def process_variable_doc(self, doc):

--- a/tests/test_samples/ct_test.cmake
+++ b/tests/test_samples/ct_test.cmake
@@ -1,0 +1,15 @@
+
+#[[[
+# This is how you document a CMakeTest test.
+#]]
+ct_add_test(NAME test1 EXPECTFAIL)
+function(${test1})
+
+    #[[[
+    # And this is how you document a CMakeTest section.
+    #]]
+    ct_add_section(NAME section1 EXPECTFAIL)
+    function(${section1})
+    endfunction()
+
+endfunction()


### PR DESCRIPTION
This pull request adds new processors to recognize documented tests and sections. Additionally, it fixes a previously unknown bug where indented docs would not be processed correctly.