### PR TITLE
Fix things licenses broke

### DIFF
--- a/.github/.licenserc.yaml
+++ b/.github/.licenserc.yaml
@@ -18,12 +18,12 @@ header:
     copyright-owner: CMakePP
 
   paths-ignore:
-    - .github/workflows/*
+    - .github/
     - cminx/parser/
     - docs/source/.templates
     - docs/source/developer/uml_diagrams/*.drawio
     - docs/Makefile
-    - tests/.coveragerc
+    - tests/
     - CODE_OF_CONDUCT.md
     - LICENSE
     - version.txt

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,19 +1,3 @@
-<!--
-  ~ Copyright 2021 CMakePP
-  ~
-  ~ Licensed under the Apache License, Version 2.0 (the "License");
-  ~ you may not use this file except in compliance with the License.
-  ~ You may obtain a copy of the License at
-  ~
-  ~ http://www.apache.org/licenses/LICENSE-2.0
-  ~
-  ~ Unless required by applicable law or agreed to in writing, software
-  ~ distributed under the License is distributed on an "AS IS" BASIS,
-  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  ~ See the License for the specific language governing permissions and
-  ~ limitations under the License.
-  ~
--->
 ---
 name: Bug report
 about: Create a report to help us improve

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,19 +1,3 @@
-<!--
-  ~ Copyright 2021 CMakePP
-  ~
-  ~ Licensed under the Apache License, Version 2.0 (the "License");
-  ~ you may not use this file except in compliance with the License.
-  ~ You may obtain a copy of the License at
-  ~
-  ~ http://www.apache.org/licenses/LICENSE-2.0
-  ~
-  ~ Unless required by applicable law or agreed to in writing, software
-  ~ distributed under the License is distributed on an "AS IS" BASIS,
-  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  ~ See the License for the specific language governing permissions and
-  ~ limitations under the License.
-  ~
--->
 ---
 name: Feature request
 about: Suggest an idea for this project

--- a/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
+++ b/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
@@ -1,0 +1,10 @@
+**Is this pull request associated with an issue(s)?**
+Please list issues associated with this pull request, including [closing words](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
+as appropriate.
+
+**Description**
+Describe what this pull request will accomplish.
+
+**TODOs**
+For draft pull requests please include a list of what needs to be done and check
+off items as you complete them.

--- a/tests/examples/example.cmake
+++ b/tests/examples/example.cmake
@@ -1,17 +1,3 @@
-# Copyright 2021 CMakePP
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-#
 #[[
 # This is a normal block comment and will not
 # be treated as a doccomment.
@@ -39,7 +25,7 @@ This documentation uses a differing format,
 but is still processed correctly.
 
 :param person: The person we want to greet.
-:type person: string 
+:type person: string
 #]]
 macro(macro_say_hi person)
    message("Hi ${person}")

--- a/tests/examples/sphinx/source/conf.py
+++ b/tests/examples/sphinx/source/conf.py
@@ -1,24 +1,4 @@
 # -*- coding: utf-8 -*-
-# Copyright 2021 CMakePP
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-#
-#
-# Configuration file for the Sphinx documentation builder.
-#
-# This file does only contain a selection of the most common options. For a
-# full list see the documentation:
-# http://www.sphinx-doc.org/en/master/config
 
 # -- Path setup --------------------------------------------------------------
 

--- a/tests/examples/sphinx/source/example.rst
+++ b/tests/examples/sphinx/source/example.rst
@@ -1,18 +1,3 @@
-.. Copyright 2021 CMakePP
-..
-.. Licensed under the Apache License, Version 2.0 (the "License");
-.. you may not use this file except in compliance with the License.
-.. You may obtain a copy of the License at
-..
-.. http://www.apache.org/licenses/LICENSE-2.0
-..
-.. Unless required by applicable law or agreed to in writing, software
-.. distributed under the License is distributed on an "AS IS" BASIS,
-.. WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-.. See the License for the specific language governing permissions and
-.. limitations under the License.
-..
-
 #############
 example.cmake
 #############
@@ -21,38 +6,38 @@ example.cmake
 
 
 .. function:: say_hi_to(person me)
-   
+
    This function has very basic documentation.
-   
+
    This function's description stays close to idealized formatting and does not do
    anything fancy.
-   
+
    :param person: The person this function says hi to
    :param me: What my name is
    :type person: string
    :type me: string
-   
+
 
 
 .. function:: macro_say_hi(person)
 
    .. warning:: This is a macro, and so does not introduce a new scope.
 
-   
+
    This macro says hi.
    This documentation uses a differing format,
    but is still processed correctly.
-   
+
    :param person: The person we want to greet.
-   :type person: string 
-   
+   :type person: string
+
 
 
 .. data:: MyList
-   
+
    This is an example of variable documentation.
    This variable is a list of string values.
-   
+
 
    :Default value: ['"Value"', '"Value 2"']
 
@@ -60,12 +45,11 @@ example.cmake
 
 
 .. data:: MyString
-   
+
    This is another example of variable documentation.
    This variable is a string variable.
-   
+
 
    :Default value: String
 
    :type: VarType.String
-

--- a/tests/examples/sphinx/source/example_prefix.rst
+++ b/tests/examples/sphinx/source/example_prefix.rst
@@ -1,18 +1,3 @@
-.. Copyright 2021 CMakePP
-..
-.. Licensed under the Apache License, Version 2.0 (the "License");
-.. you may not use this file except in compliance with the License.
-.. You may obtain a copy of the License at
-..
-.. http://www.apache.org/licenses/LICENSE-2.0
-..
-.. Unless required by applicable law or agreed to in writing, software
-.. distributed under the License is distributed on an "AS IS" BASIS,
-.. WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-.. See the License for the specific language governing permissions and
-.. limitations under the License.
-..
-
 ####################
 prefix.example.cmake
 ####################
@@ -21,38 +6,38 @@ prefix.example.cmake
 
 
 .. function:: say_hi_to(person me)
-   
+
    This function has very basic documentation.
-   
+
    This function's description stays close to idealized formatting and does not do
    anything fancy.
-   
+
    :param person: The person this function says hi to
    :param me: What my name is
    :type person: string
    :type me: string
-   
+
 
 
 .. function:: macro_say_hi(person)
 
    .. warning:: This is a macro, and so does not introduce a new scope.
 
-   
+
    This macro says hi.
    This documentation uses a differing format,
    but is still processed correctly.
-   
+
    :param person: The person we want to greet.
-   :type person: string 
-   
+   :type person: string
+
 
 
 .. data:: MyList
-   
+
    This is an example of variable documentation.
    This variable is a list of string values.
-   
+
 
    :Default value: ['"Value"', '"Value 2"']
 
@@ -60,12 +45,11 @@ prefix.example.cmake
 
 
 .. data:: MyString
-   
+
    This is another example of variable documentation.
    This variable is a string variable.
-   
+
 
    :Default value: String
 
    :type: VarType.String
-

--- a/tests/examples/sphinx/source/index.rst
+++ b/tests/examples/sphinx/source/index.rst
@@ -1,17 +1,3 @@
-.. Copyright 2021 CMakePP
-..
-.. Licensed under the Apache License, Version 2.0 (the "License");
-.. you may not use this file except in compliance with the License.
-.. You may obtain a copy of the License at
-..
-.. http://www.apache.org/licenses/LICENSE-2.0
-..
-.. Unless required by applicable law or agreed to in writing, software
-.. distributed under the License is distributed on an "AS IS" BASIS,
-.. WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-.. See the License for the specific language governing permissions and
-.. limitations under the License.
-..
 .. CMinx Examples documentation master file, created by
    sphinx-quickstart on Tue Mar 10 20:13:09 2020.
    You can adapt this file completely to your liking, but it should at least
@@ -23,7 +9,7 @@ Welcome to CMinx Examples's documentation!
 .. toctree::
    :maxdepth: 2
    :caption: Contents:
-   
+
    example
 
 

--- a/tests/test_samples/advanced_function.cmake
+++ b/tests/test_samples/advanced_function.cmake
@@ -1,17 +1,3 @@
-# Copyright 2021 CMakePP
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-#
 #[[[
 # Variation of say_hi_to, which takes lists of people and cats to say hi to.
 #

--- a/tests/test_samples/basic_function.cmake
+++ b/tests/test_samples/basic_function.cmake
@@ -1,17 +1,3 @@
-# Copyright 2021 CMakePP
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-#
 include_guard()
 
 #[[[

--- a/tests/test_samples/basic_macro.cmake
+++ b/tests/test_samples/basic_macro.cmake
@@ -1,17 +1,3 @@
-# Copyright 2021 CMakePP
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-#
 #[[[
 # This macro says hi.
 # This documentation uses a differing format,

--- a/tests/test_samples/corr_rst/advanced_function.rst
+++ b/tests/test_samples/corr_rst/advanced_function.rst
@@ -1,17 +1,3 @@
-.. Copyright 2021 CMakePP
-..
-.. Licensed under the Apache License, Version 2.0 (the "License");
-.. you may not use this file except in compliance with the License.
-.. You may obtain a copy of the License at
-..
-.. http://www.apache.org/licenses/LICENSE-2.0
-..
-.. Unless required by applicable law or agreed to in writing, software
-.. distributed under the License is distributed on an "AS IS" BASIS,
-.. WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-.. See the License for the specific language governing permissions and
-.. limitations under the License.
-..
 
 #######################
 advanced_function.cmake
@@ -21,18 +7,16 @@ advanced_function.cmake
 
 
 .. function:: advanced_say_hi_to(me)
-   
+
    Variation of say_hi_to, which takes lists of people and cats to say hi to.
-   
+
    This function is basically the same as ``say_hi_to``, but accounts for the
    fact that you may want to say hi to multiple people and maybe even a cat or
    two.
-   
+
    :param me: The name of the person saying hi.
    :type me: string
    :keyword PERSONS: The person or persons to say hi to.
    :type PERSONS: list of strings
    :keyword CATS: The cat or cats to say hi to.
    :type CATS: list of strings
-   
-

--- a/tests/test_samples/corr_rst/basic_function.rst
+++ b/tests/test_samples/corr_rst/basic_function.rst
@@ -1,17 +1,3 @@
-.. Copyright 2021 CMakePP
-..
-.. Licensed under the Apache License, Version 2.0 (the "License");
-.. you may not use this file except in compliance with the License.
-.. You may obtain a copy of the License at
-..
-.. http://www.apache.org/licenses/LICENSE-2.0
-..
-.. Unless required by applicable law or agreed to in writing, software
-.. distributed under the License is distributed on an "AS IS" BASIS,
-.. WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-.. See the License for the specific language governing permissions and
-.. limitations under the License.
-..
 
 ####################
 basic_function.cmake
@@ -21,13 +7,11 @@ basic_function.cmake
 
 
 .. function:: say_hi_to(person)
-   
+
    This function has very basic documentation.
-   
+
    This function's description stays close to idealized formatting and does not do
    anything fancy.
-   
+
    :param person: The person this function says hi to
    :type person: string
-   
-

--- a/tests/test_samples/corr_rst/basic_macro.rst
+++ b/tests/test_samples/corr_rst/basic_macro.rst
@@ -1,17 +1,3 @@
-.. Copyright 2021 CMakePP
-..
-.. Licensed under the Apache License, Version 2.0 (the "License");
-.. you may not use this file except in compliance with the License.
-.. You may obtain a copy of the License at
-..
-.. http://www.apache.org/licenses/LICENSE-2.0
-..
-.. Unless required by applicable law or agreed to in writing, software
-.. distributed under the License is distributed on an "AS IS" BASIS,
-.. WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-.. See the License for the specific language governing permissions and
-.. limitations under the License.
-..
 
 #################
 basic_macro.cmake
@@ -24,12 +10,10 @@ basic_macro.cmake
 
    .. warning:: This is a macro, and so does not introduce a new scope.
 
-   
+
    This macro says hi.
    This documentation uses a differing format,
    but is still processed correctly.
-   
+
    :param person: The person we want to greet.
    :type person: string
-   
-

--- a/tests/test_samples/corr_rst/ct_test.rst
+++ b/tests/test_samples/corr_rst/ct_test.rst
@@ -1,17 +1,3 @@
-.. Copyright 2021 CMakePP
-..
-.. Licensed under the Apache License, Version 2.0 (the "License");
-.. you may not use this file except in compliance with the License.
-.. You may obtain a copy of the License at
-..
-.. http://www.apache.org/licenses/LICENSE-2.0
-..
-.. Unless required by applicable law or agreed to in writing, software
-.. distributed under the License is distributed on an "AS IS" BASIS,
-.. WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-.. See the License for the specific language governing permissions and
-.. limitations under the License.
-..
 
 #############
 ct_test.cmake
@@ -24,16 +10,14 @@ ct_test.cmake
 
    .. warning:: This is a CMakeTest test definition, do not call this manually.
 
-   
+
    This is how you document a CMakeTest test.
-   
+
 
 
 .. function:: section1(EXPECTFAIL)
 
    .. warning:: This is a CMakeTest section definition, do not call this manually.
 
-   
-   And this is how you document a CMakeTest section.
-   
 
+   And this is how you document a CMakeTest section.

--- a/tests/test_samples/corr_rst/index.rst
+++ b/tests/test_samples/corr_rst/index.rst
@@ -1,23 +1,9 @@
-.. Copyright 2021 CMakePP
-..
-.. Licensed under the Apache License, Version 2.0 (the "License");
-.. you may not use this file except in compliance with the License.
-.. You may obtain a copy of the License at
-..
-.. http://www.apache.org/licenses/LICENSE-2.0
-..
-.. Unless required by applicable law or agreed to in writing, software
-.. distributed under the License is distributed on an "AS IS" BASIS,
-.. WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-.. See the License for the specific language governing permissions and
-.. limitations under the License.
-..
 
 #
 .
 #
 
-.. toctree:: 
+.. toctree::
    :maxdepth: 2
    basic_macro
    basic_function
@@ -25,4 +11,3 @@
    variable
    ct_test
    advanced_function
-

--- a/tests/test_samples/corr_rst/quickstart.rst
+++ b/tests/test_samples/corr_rst/quickstart.rst
@@ -1,17 +1,3 @@
-.. Copyright 2021 CMakePP
-..
-.. Licensed under the Apache License, Version 2.0 (the "License");
-.. you may not use this file except in compliance with the License.
-.. You may obtain a copy of the License at
-..
-.. http://www.apache.org/licenses/LICENSE-2.0
-..
-.. Unless required by applicable law or agreed to in writing, software
-.. distributed under the License is distributed on an "AS IS" BASIS,
-.. WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-.. See the License for the specific language governing permissions and
-.. limitations under the License.
-..
 
 ################
 quickstart.cmake
@@ -21,12 +7,10 @@ quickstart.cmake
 
 
 .. function:: quickstart(param0)
-   
-   A brief description.
-   
-   A more detailed description, must be separated from the brief by at least 
-   one blank line.
-   
-   :param param0: The 0-th parameter passed to the function
-   
 
+   A brief description.
+
+   A more detailed description, must be separated from the brief by at least
+   one blank line.
+
+   :param param0: The 0-th parameter passed to the function

--- a/tests/test_samples/corr_rst/variable.rst
+++ b/tests/test_samples/corr_rst/variable.rst
@@ -1,17 +1,3 @@
-.. Copyright 2021 CMakePP
-..
-.. Licensed under the Apache License, Version 2.0 (the "License");
-.. you may not use this file except in compliance with the License.
-.. You may obtain a copy of the License at
-..
-.. http://www.apache.org/licenses/LICENSE-2.0
-..
-.. Unless required by applicable law or agreed to in writing, software
-.. distributed under the License is distributed on an "AS IS" BASIS,
-.. WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-.. See the License for the specific language governing permissions and
-.. limitations under the License.
-..
 
 ##############
 variable.cmake
@@ -21,12 +7,11 @@ variable.cmake
 
 
 .. data:: MyList
-   
+
    This is an example of variable documentation.
    This variable is a list of string values.
-   
+
 
    :Default value: ['"Value"', '"Value 2"']
 
    :type: VarType.List
-

--- a/tests/test_samples/ct_test.cmake
+++ b/tests/test_samples/ct_test.cmake
@@ -1,17 +1,3 @@
-# Copyright 2021 CMakePP
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-#
 #[[[
 # This is how you document a CMakeTest test.
 #]]

--- a/tests/test_samples/quickstart.cmake
+++ b/tests/test_samples/quickstart.cmake
@@ -1,21 +1,7 @@
-# Copyright 2021 CMakePP
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-#
-#[[[ 
+#[[[
 # A brief description.
 #
-# A more detailed description, must be separated from the brief by at least 
+# A more detailed description, must be separated from the brief by at least
 # one blank line.
 #
 # :param param0: The 0-th parameter passed to the function

--- a/tests/test_samples/variable.cmake
+++ b/tests/test_samples/variable.cmake
@@ -1,17 +1,3 @@
-# Copyright 2021 CMakePP
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-#
 #[[[
 # This is an example of variable documentation.
 # This variable is a list of string values.


### PR DESCRIPTION
The automatic application of licenses is great, but I got a little over zealous with it and broke:

- the code examples in the documentation (the line numbers all changed)
- the unit tests (only sort of broke; since the licenses were added to both the generated files and the originals, the tests still passed it just wasn't content that CMinx would actually generate)
- issue templates (apparently they can't start with a license)

This PR fixes that stuff and updates the `.licenserc.yaml` file so it hopefully won't happen again...