### PR TITLE
Fix minor whitespace inconsistencies in correct RST

### DIFF
--- a/tests/examples/sphinx/source/example.rst
+++ b/tests/examples/sphinx/source/example.rst
@@ -1,3 +1,4 @@
+
 #############
 example.cmake
 #############
@@ -6,38 +7,38 @@ example.cmake
 
 
 .. function:: say_hi_to(person me)
-
+   
    This function has very basic documentation.
-
+   
    This function's description stays close to idealized formatting and does not do
    anything fancy.
-
+   
    :param person: The person this function says hi to
    :param me: What my name is
    :type person: string
    :type me: string
-
+   
 
 
 .. function:: macro_say_hi(person)
 
    .. warning:: This is a macro, and so does not introduce a new scope.
 
-
+   
    This macro says hi.
    This documentation uses a differing format,
    but is still processed correctly.
-
+   
    :param person: The person we want to greet.
    :type person: string
-
+   
 
 
 .. data:: MyList
-
+   
    This is an example of variable documentation.
    This variable is a list of string values.
-
+   
 
    :Default value: ['"Value"', '"Value 2"']
 
@@ -45,11 +46,12 @@ example.cmake
 
 
 .. data:: MyString
-
+   
    This is another example of variable documentation.
    This variable is a string variable.
-
+   
 
    :Default value: String
 
    :type: VarType.String
+

--- a/tests/examples/sphinx/source/example_prefix.rst
+++ b/tests/examples/sphinx/source/example_prefix.rst
@@ -1,3 +1,4 @@
+
 ####################
 prefix.example.cmake
 ####################
@@ -6,38 +7,38 @@ prefix.example.cmake
 
 
 .. function:: say_hi_to(person me)
-
+   
    This function has very basic documentation.
-
+   
    This function's description stays close to idealized formatting and does not do
    anything fancy.
-
+   
    :param person: The person this function says hi to
    :param me: What my name is
    :type person: string
    :type me: string
-
+   
 
 
 .. function:: macro_say_hi(person)
 
    .. warning:: This is a macro, and so does not introduce a new scope.
 
-
+   
    This macro says hi.
    This documentation uses a differing format,
    but is still processed correctly.
-
+   
    :param person: The person we want to greet.
    :type person: string
-
+   
 
 
 .. data:: MyList
-
+   
    This is an example of variable documentation.
    This variable is a list of string values.
-
+   
 
    :Default value: ['"Value"', '"Value 2"']
 
@@ -45,11 +46,12 @@ prefix.example.cmake
 
 
 .. data:: MyString
-
+   
    This is another example of variable documentation.
    This variable is a string variable.
-
+   
 
    :Default value: String
 
    :type: VarType.String
+

--- a/tests/test_samples/corr_rst/advanced_function.rst
+++ b/tests/test_samples/corr_rst/advanced_function.rst
@@ -7,16 +7,18 @@ advanced_function.cmake
 
 
 .. function:: advanced_say_hi_to(me)
-
+   
    Variation of say_hi_to, which takes lists of people and cats to say hi to.
-
+   
    This function is basically the same as ``say_hi_to``, but accounts for the
    fact that you may want to say hi to multiple people and maybe even a cat or
    two.
-
+   
    :param me: The name of the person saying hi.
    :type me: string
    :keyword PERSONS: The person or persons to say hi to.
    :type PERSONS: list of strings
    :keyword CATS: The cat or cats to say hi to.
    :type CATS: list of strings
+   
+

--- a/tests/test_samples/corr_rst/basic_function.rst
+++ b/tests/test_samples/corr_rst/basic_function.rst
@@ -7,11 +7,13 @@ basic_function.cmake
 
 
 .. function:: say_hi_to(person)
-
+   
    This function has very basic documentation.
-
+   
    This function's description stays close to idealized formatting and does not do
    anything fancy.
-
+   
    :param person: The person this function says hi to
    :type person: string
+   
+

--- a/tests/test_samples/corr_rst/basic_macro.rst
+++ b/tests/test_samples/corr_rst/basic_macro.rst
@@ -10,10 +10,12 @@ basic_macro.cmake
 
    .. warning:: This is a macro, and so does not introduce a new scope.
 
-
+   
    This macro says hi.
    This documentation uses a differing format,
    but is still processed correctly.
-
+   
    :param person: The person we want to greet.
    :type person: string
+   
+

--- a/tests/test_samples/corr_rst/ct_test.rst
+++ b/tests/test_samples/corr_rst/ct_test.rst
@@ -10,14 +10,16 @@ ct_test.cmake
 
    .. warning:: This is a CMakeTest test definition, do not call this manually.
 
-
+   
    This is how you document a CMakeTest test.
-
+   
 
 
 .. function:: section1(EXPECTFAIL)
 
    .. warning:: This is a CMakeTest section definition, do not call this manually.
 
-
+   
    And this is how you document a CMakeTest section.
+   
+

--- a/tests/test_samples/corr_rst/quickstart.rst
+++ b/tests/test_samples/corr_rst/quickstart.rst
@@ -7,10 +7,12 @@ quickstart.cmake
 
 
 .. function:: quickstart(param0)
-
+   
    A brief description.
-
+   
    A more detailed description, must be separated from the brief by at least
    one blank line.
-
+   
    :param param0: The 0-th parameter passed to the function
+   
+

--- a/tests/test_samples/corr_rst/variable.rst
+++ b/tests/test_samples/corr_rst/variable.rst
@@ -7,11 +7,12 @@ variable.cmake
 
 
 .. data:: MyList
-
+   
    This is an example of variable documentation.
    This variable is a list of string values.
-
+   
 
    :Default value: ['"Value"', '"Value 2"']
 
    :type: VarType.List
+


### PR DESCRIPTION
This fixes several issues in the correct RST for tests in which whitespace is slightly different and therefore fails the tests.

Should fix #46, although we should probably find a way to update coverage if tests fail.