### PR TITLE
Make pip_install workflow trigger on pushes to master

### DIFF
--- a/.github/workflows/pip_install.yaml
+++ b/.github/workflows/pip_install.yaml
@@ -15,6 +15,9 @@
 name: CMinx Installed via PIP
 
 on:
+  push:
+    branches:
+      - master
   pull_request:
     branches:
       - master


### PR DESCRIPTION
This pull request should cause the pip_install workflow to trigger on all pushes to master, which includes the merging of other PRs. Since that workflow triggers testing and coverage reports this should also fix #46. @ryanmrichard do we also want to run the  add_licenses and cmake_install workflows on pushes to master or leave those as is?