### PR TITLE
Support dynamic parameters

### DIFF
--- a/tests/examples/example.cmake
+++ b/tests/examples/example.cmake
@@ -35,21 +35,41 @@ endmacro()
 set(MyFunctionName "Name_Of_A_Function")
 
 #[[[
-# This is a documented macro, but the name
-# is dynamically assigned so it can't be documented.
+# This is a documented function, but the name
+# is dynamically assigned.
 #]]
-macro("${MyFunctionName}")
-endmacro()
+function("${MyFunctionName}")
+endfunction()
+
+set(MyFunctionParamName "Name_Of_A_Param")
+
+#[[[
+# This is a documented function, but the first parameter name
+# is dynamically assigned.
+#]]
+function("function_with_var_param_name" "${MyFunctionParamName}")
+endfunction()
+
 
 
 set(MyMacroName "Name_Of_A_Macro")
 
 #[[[
 # This is a documented macro, but the name
-# is dynamically assigned so it can't be documented.
+# is dynamically assigned.
 #]]
 macro("${MyMacroName}")
 endmacro()
+
+set(MyMacroParamName "Name_Of_A_Param")
+
+#[[[
+# This is a documented macro, but the first parameter name
+# is dynamically assigned.
+#]]
+function("macro_with_var_param_name" "${MyMacroParamName}") 
+endfunction()
+
 
 #[[[
 # This is an example of variable documentation.

--- a/tests/examples/sphinx/source/example.rst
+++ b/tests/examples/sphinx/source/example.rst
@@ -34,6 +34,37 @@ examples.example
    
 
 
+.. function:: "${MyFunctionName}"()
+
+   This is a documented function, but the name
+   is dynamically assigned.
+   
+
+
+.. function:: "function_with_var_param_name"("${MyFunctionParamName}")
+
+   This is a documented function, but the first parameter name
+   is dynamically assigned.
+   
+
+
+.. function:: "${MyMacroName}"()
+
+
+   .. warning:: This is a macro, and so does not introduce a new scope.
+
+   This is a documented macro, but the name
+   is dynamically assigned.
+   
+
+
+.. function:: "macro_with_var_param_name"("${MyMacroParamName}")
+
+   This is a documented macro, but the first parameter name
+   is dynamically assigned.
+   
+
+
 .. data:: MyList
 
    This is an example of variable documentation.

--- a/tests/examples/sphinx/source/example_prefix.rst
+++ b/tests/examples/sphinx/source/example_prefix.rst
@@ -34,6 +34,37 @@ prefix.example
    
 
 
+.. function:: "${MyFunctionName}"()
+
+   This is a documented function, but the name
+   is dynamically assigned.
+   
+
+
+.. function:: "function_with_var_param_name"("${MyFunctionParamName}")
+
+   This is a documented function, but the first parameter name
+   is dynamically assigned.
+   
+
+
+.. function:: "${MyMacroName}"()
+
+
+   .. warning:: This is a macro, and so does not introduce a new scope.
+
+   This is a documented macro, but the name
+   is dynamically assigned.
+   
+
+
+.. function:: "macro_with_var_param_name"("${MyMacroParamName}")
+
+   This is a documented macro, but the first parameter name
+   is dynamically assigned.
+   
+
+
 .. data:: MyList
 
    This is an example of variable documentation.


### PR DESCRIPTION
**Description**
Adds support to CMinx to document dynamically generated function and macro parameter names. For example:
```cmake
set(MyFunctionParamName "Name_Of_A_Param")

#[[[
# This is a documented function, but the first parameter name
# is dynamically assigned.
#]]
function("function_with_var_param_name" "${MyFunctionParamName}")
endfunction()

```
The above will now be documented as the following RST:
```rst
.. function:: "function_with_var_param_name"("${MyFunctionParamName}")

   This is a documented function, but the first parameter name
   is dynamically assigned.


```
This has been verified to work with Sphinx version 4.5.0 with the default theme