### PR TITLE
bump python version

### DIFF
--- a/.github/workflows/deploy_docs.yaml
+++ b/.github/workflows/deploy_docs.yaml
@@ -26,7 +26,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v1
         with:
-          python-version: '3.7'
+          python-version: '3.10'
       - name: Build Docs
         run: |
           python3 -m venv virt_env

--- a/.github/workflows/tag_and_release.yaml
+++ b/.github/workflows/tag_and_release.yaml
@@ -23,4 +23,4 @@ jobs:
   release:
     uses: CMakePP/.github/.github/workflows/tag_and_release_master.yaml@main
     secrets:
-      token: ${{ secrets.GITHUB_TOKEN }}
+      token: ${{ secrets.UPDATED_VERSION_TXT }}

--- a/.github/workflows/tag_and_release.yaml
+++ b/.github/workflows/tag_and_release.yaml
@@ -23,4 +23,4 @@ jobs:
   release:
     uses: CMakePP/.github/.github/workflows/tag_and_release_master.yaml@main
     secrets:
-      token: ${{ secrets.UPDATED_VERSION_TXT }}
+      token: ${{ secrets.UPDATE_VERSION_TXT }}


### PR DESCRIPTION
Based on private conversations the deploy docs is failing because of the Python version, this bumps the version so it should deploy :crossed_fingers:.
