### PR TITLE
Fixed 'List' type annotations for Python 3.8

### DIFF
--- a/cminx/__init__.py
+++ b/cminx/__init__.py
@@ -43,6 +43,7 @@ import logging
 import os
 import re
 import sys
+from typing import List
 import logging.config
 import pathspec
 from fnmatch import fnmatch
@@ -63,7 +64,7 @@ except DistributionNotFound:
 logger: logging.Logger = logging.getLogger(__name__)
 
 
-def main(args: list[str] = tuple(sys.argv[1:])):
+def main(args: List[str] = tuple(sys.argv[1:])):
     """
     CMake Documentation Generator program entry point.
 

--- a/cminx/__init__.py
+++ b/cminx/__init__.py
@@ -43,10 +43,10 @@ import logging
 import os
 import re
 import sys
-from typing import List
 import logging.config
 import pathspec
 from fnmatch import fnmatch
+from typing import List
 
 from confuse import Configuration
 from pkg_resources import get_distribution, DistributionNotFound

--- a/cminx/config.py
+++ b/cminx/config.py
@@ -69,7 +69,7 @@ class InputSettings:
     include_undocumented_ct_add_test: bool = True
     include_undocumented_ct_add_section: bool = True
     auto_exclude_directories_without_cmake: bool = True
-    exclude_filters: list[str] = ()
+    exclude_filters: List[str] = ()
     recursive: bool = False
     follow_symlinks: bool = False
 


### PR DESCRIPTION
**Description**
Fixes type annotations incompatible with Python 3.8. Specifically, `list[<type>]` is incompatible and gives a `TypeError: 'type' object is not subscriptable` error, while `List[<type>]` works if you import `from typing import List`. 
