### PR TITLE
Expand CI Version Coverage

### DIFF
--- a/.github/workflows/cmake_install.yaml
+++ b/.github/workflows/cmake_install.yaml
@@ -23,16 +23,21 @@ jobs:
   build:
     runs-on: ubuntu-latest
 
+    strategy:
+      matrix:
+        python_version: [3.8, 3.9, 3.10]
+
     steps:
       - uses: actions/checkout@v1
         with:
           fetch-depth: 0
       - uses: actions/setup-python@v1
         with:
-          python-version: '3.9'
+          python-version: ${{ matrix.python_version }}
       - uses: lukka/get-cmake@v3.20.1
       - name: Build
         run: |
+          python3 --version
           cmake -S . -B build -DCMAKE_INSTALL_PREFIX=`pwd`/install -DBUILD_TESTING=ON
           cmake --build build
           cmake --install build

--- a/.github/workflows/cmake_install.yaml
+++ b/.github/workflows/cmake_install.yaml
@@ -25,7 +25,7 @@ jobs:
 
     strategy:
       matrix:
-        python_version: [3.8, 3.9, 3.10]
+        python_version: ['3.8.13', '3.9.13', '3.10.5']
 
     steps:
       - uses: actions/checkout@v1

--- a/.github/workflows/pip_install.yaml
+++ b/.github/workflows/pip_install.yaml
@@ -28,7 +28,7 @@ jobs:
 
     strategy:
       matrix:
-        python_version: [3.8, 3.9, 3.10]
+        python_version: ['3.8.13', '3.9.13', '3.10.5']
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/pip_install.yaml
+++ b/.github/workflows/pip_install.yaml
@@ -26,13 +26,17 @@ jobs:
   build-pip:
     runs-on: ubuntu-latest
 
+    strategy:
+      matrix:
+        python_versions: [3.8, 3.9, 3.10]
+
     steps:
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0
       - uses: actions/setup-python@v1
         with:
-          python-version: '3.9'
+          python-version: ${{ matrix.python_version }}
       - name: Build
         run: |
           python3 -m venv virt_env

--- a/.github/workflows/pip_install.yaml
+++ b/.github/workflows/pip_install.yaml
@@ -28,7 +28,7 @@ jobs:
 
     strategy:
       matrix:
-        python_versions: [3.8, 3.9, 3.10]
+        python_version: [3.8, 3.9, 3.10]
 
     steps:
       - uses: actions/checkout@v2
@@ -39,6 +39,7 @@ jobs:
           python-version: ${{ matrix.python_version }}
       - name: Build
         run: |
+          python3 --version
           python3 -m venv virt_env
           source virt_env/bin/activate
           pip3 install wheel

--- a/cminx/__init__.py
+++ b/cminx/__init__.py
@@ -115,10 +115,9 @@ def main(args: List[str] = tuple(sys.argv[1:])):
         "-e",
         "--exclude",
         help="Exclude some files from documentation. Supports shell-style glob syntax, relative paths "
-             "are resolved with respect to the current working directory.",
+        "are resolved with respect to the current working directory.",
         dest="input.exclude_filters",
-        action="append"
-    )
+        action="append")
     parser.add_argument(
         "--version",
         action='version',
@@ -137,12 +136,14 @@ def main(args: List[str] = tuple(sys.argv[1:])):
     if settings["output"]["relative_to_config"].get():
         output_dir_relative_to_config = True
 
-    settings_dict = settings.get(config_template(output_dir_relative_to_config))
+    settings_dict = settings.get(
+        config_template(output_dir_relative_to_config))
 
     settings_obj = dict_to_settings(settings_dict)
 
     # Concatenate all exclude filters rather than overriding the entire list
-    settings_obj.input.exclude_filters = list(settings["input"]["exclude_filters"].all_contents())
+    settings_obj.input.exclude_filters = list(
+        settings["input"]["exclude_filters"].all_contents())
 
     logging.config.dictConfig(settings_obj.logging.logger_config)
     logger = logging.getLogger(__name__)
@@ -209,7 +210,7 @@ def document_single_file(file, root, settings: Settings):
             output_filename = os.path.join(
                 output_path, ".".join(
                     os.path.basename(file).split(".")[
-                    :-1]) + ".rst")
+                        :-1]) + ".rst")
             if os.path.isdir(root):
                 # Path to file relative to input_path
                 subpath = os.path.relpath(file, root)
@@ -217,7 +218,7 @@ def document_single_file(file, root, settings: Settings):
                     output_path, os.path.join(
                         os.path.dirname(subpath), ".".join(
                             os.path.basename(file).split(".")[
-                            :-1]) + ".rst"))
+                                :-1]) + ".rst"))
             logger.info(f"Writing RST file {output_filename}")
             output_writer.write_to_file(output_filename)
     else:  # Output was not specified so print to screen
@@ -245,7 +246,9 @@ def document(input_file: str, settings: Settings):
         # os.path.join() adds a trailing slash to directories if absent
         input_path = os.path.join(input_path, '')
 
-    spec = pathspec.PathSpec.from_lines(pathspec.patterns.GitWildMatchPattern, settings.input.exclude_filters)
+    spec = pathspec.PathSpec.from_lines(
+        pathspec.patterns.GitWildMatchPattern,
+        settings.input.exclude_filters)
 
     logger.debug(f"Input path: {input_path}")
 
@@ -261,14 +264,21 @@ def document(input_file: str, settings: Settings):
         new_settings.rst.prefix = prefix
 
         # Walk dir and add cmake files to list
-        for root, subdirs, filenames in os.walk(input_path, topdown=True, followlinks=settings.input.follow_symlinks):
+        for root, subdirs, filenames in os.walk(
+                input_path, topdown=True, followlinks=settings.input.follow_symlinks):
 
             logger.debug(f"Subdirs: {subdirs}")
             logger.debug(f"Root: {root}")
 
             for subdir in subdirs:
-                # The extra os.path.join() with an empty string ensures the directory has a trailing slash
-                if spec.match_file(os.path.join(root, os.path.join(subdir, ""))):
+                # The extra os.path.join() with an empty string ensures the
+                # directory has a trailing slash
+                if spec.match_file(
+                    os.path.join(
+                        root,
+                        os.path.join(
+                            subdir,
+                            ""))):
                     subdirs.remove(subdir)
 
             for file in filenames:
@@ -283,13 +293,15 @@ def document(input_file: str, settings: Settings):
             #         filenames.remove(filename)
 
             if settings.input.auto_exclude_directories_without_cmake:
-                # Make a copy because modifying while iterating results in skipping some entries
+                # Make a copy because modifying while iterating results in
+                # skipping some entries
                 for subdir in copy.copy(subdirs):
                     logger.debug(f"Checking filenames in subdir {subdir}")
                     for filename in os.scandir(os.path.join(root, subdir)):
                         if filename.is_file() and filename.path.endswith(".cmake"):
                             break
-                    # If we exited loop normally, i.e. a .cmake file was not found
+                    # If we exited loop normally, i.e. a .cmake file was not
+                    # found
                     else:
                         subdirs.remove(subdir)
                 for filename in filenames:
@@ -323,7 +335,7 @@ def document(input_file: str, settings: Settings):
                 toctree = index.directive("toctree")
                 toctree.option("maxdepth", 2)
                 for file in [
-                    f for f in filenames if f.lower().endswith(".cmake")]:
+                        f for f in filenames if f.lower().endswith(".cmake")]:
                     toctree.text('.'.join(file.split('.')[:-1]))
                 if recursive:
                     for directory in subdirs:


### PR DESCRIPTION
Prior to this PR our CI was only testing Python 3.9. This PR expands our CI so that we test all
versions of Python we support (right now defined as 3.8, 3.9, and 3.10).

I need to update the CMake-based CI script also, but wanted to make sure that the Python one worked first.