### PR TITLE
Adds pip package test and auto deploy

### DIFF
--- a/.github/workflows/tag_and_release.yaml
+++ b/.github/workflows/tag_and_release.yaml
@@ -20,7 +20,15 @@ on:
       - master
 
 jobs:
-  release:
+  tag:
     uses: CMakePP/.github/.github/workflows/tag_and_release_master.yaml@main
     secrets:
       token: ${{ secrets.UPDATE_VERSION_TXT }}
+  release:
+    needs: tag
+    if: | 
+      (needs.tag.outputs.bumped_major == 'true') || 
+      (needs.tag.outputs.bumped_minor == 'true')
+    uses: CMakePP/.github/.github/workflows/pypi_release_master.yaml
+    secrets:
+      token: ${{ secrets.PYPI_API_TOKEN }}

--- a/.github/workflows/tag_and_release.yaml
+++ b/.github/workflows/tag_and_release.yaml
@@ -29,6 +29,6 @@ jobs:
     if: | 
       (needs.tag.outputs.bumped_major == 'true') || 
       (needs.tag.outputs.bumped_minor == 'true')
-    uses: CMakePP/.github/.github/workflows/pypi_release_master.yaml
+    uses: CMakePP/.github/.github/workflows/pypi_release_master.yaml@main
     secrets:
       token: ${{ secrets.PYPI_API_TOKEN }}

--- a/.github/workflows/test_pip_install.yaml
+++ b/.github/workflows/test_pip_install.yaml
@@ -1,0 +1,41 @@
+ # Copyright 2022 CMakePP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+name: Test PyPI Release
+
+on:
+  pull_request:
+    branches:
+      - master
+      
+jobs:
+  test_release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+      - name: Get the tags
+        run: git fetch --all --tags
+      - name: Install Python's "build" package
+        run: python -m pip install build twine --user
+      - name: Build binary wheel and source tarball
+        run: python -m build --sdist --wheel --outdir dist/
+      - name: Test Long Description
+        run: twine check dist/*
+      - name: Test built package
+        run: |
+          pip install dist/*.tar.gz
+          cd tests
+          python -B test_all.py  


### PR DESCRIPTION
**Is this pull request associated with an issue(s)?**
This adds the actions called for in #69

**Description**
This PR:
- adds an action `test_pip_install.yaml` which runs on every PR. This action will:
  - ensure that the PR can be built as a PyPI package, 
  - locally install the resulting PyPI package, and 
  - test that the locally installed PyPI package passes the unit tests.
- Extends `tag_and_release.yaml` so that when the major or minor of CMinx changes, we deploy a new PyPI package.

**TODOs**
None.
