### PR TITLE
Fix typo in `variable.rst`

### DIFF
--- a/docs/source/documenting/variable.rst
+++ b/docs/source/documenting/variable.rst
@@ -17,7 +17,7 @@ Documenting a Variable
 **********************
 
 CMinx supports documenting variables. The process is identical to documenting a
-function or macro, except that the documentation comment proceeds a ``set``
+function or macro, except that the documentation comment precedes a ``set``
 command. An example:
 
 .. literalinclude:: ../../../tests/test_samples/variable.cmake


### PR DESCRIPTION
Related to openjournals/joss-reviews#4680


**Is this pull request associated with an issue(s)?**
No

**Description**
Just fixing a typo in the documentation.

