### PR TITLE
try to solve 122

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -66,7 +66,12 @@ exclude_patterns = ['build', '.templates']
 pygments_style = 'sphinx'
 # Required theme setup
 html_theme = 'sphinx_rtd_theme'
-
+html_theme_options = {
+    'vcs_pageview_mode' : 'edit'
+}
+html_context = {
+    'display_github' : True,
+}
 htmlhelp_basename = project + 'doc'
 extensions = [
     'sphinx.ext.mathjax',


### PR DESCRIPTION
**Is this pull request associated with an issue(s)?**
I think this fixes #122.

**Description**
Locally I have confirmed that this PR does indeed add the "edit on GitHub" button; however, locally, the URL it tries to take you to is a 404. This appears to be because it uses the local file path to generate the URL. I'm hoping that this issue goes away when the documentation is actually deployed.

**TODOs**
Verify that merging this PR does indeed result in usable links (if not I'll reopen the issue).
