### PR TITLE
Update .licenserc.yaml

### DIFF
--- a/.github/.licenserc.yaml
+++ b/.github/.licenserc.yaml
@@ -27,6 +27,7 @@ header:
     - LICENSE
     - MANIFEST.in
     - setup.cfg
+    - *.txt
 
 
   comment: never


### PR DESCRIPTION
The upstream license action doesn't seem to be skipping .txt files anymore. This should fix that.