### PR TITLE
Update codecov.yml

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -18,3 +18,5 @@ ignore:
   - "src/cminx/parser/CMakeParser.py"
   - "src/cminx/parser/CMakeListener.py"
   - "src/cminx/parser/CMakeLexer.py"
+codecov: 
+ token: 3c6e3d73-cf40-4b28-ae6d-e968d7f759fa

--- a/src/cminx/exceptions.py
+++ b/src/cminx/exceptions.py
@@ -1,3 +1,17 @@
+# Copyright 2022 CMakePP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import dataclasses
 
 


### PR DESCRIPTION
This is meant to replace #135. Hopefully now that the license version is pinned we won't have the license issue.