### PR TITLE
139 add documentation generation for option

### DIFF
--- a/src/cminx/aggregator.py
+++ b/src/cminx/aggregator.py
@@ -17,7 +17,8 @@ from typing import List
 
 from .documentation_types import AttributeDocumentation, FunctionDocumentation, MacroDocumentation, \
     VariableDocumentation, GenericCommandDocumentation, ClassDocumentation, TestDocumentation, SectionDocumentation, \
-    MethodDocumentation, VarType, CTestDocumentation, ModuleDocumentation, AbstractCommandDefinitionDocumentation
+    MethodDocumentation, VarType, CTestDocumentation, ModuleDocumentation, AbstractCommandDefinitionDocumentation, \
+    OptionDocumentation
 from .exceptions import CMakeSyntaxException
 from .parser.CMakeListener import CMakeListener
 # Annoyingly, the Antl4 Python libraries use camelcase since it was originally Java, so we have convention
@@ -434,9 +435,35 @@ class DocumentationAggregator(CMakeListener):
                     self.logger.error(f"add_test() called with incorrect parameters: {params}\n\n{pretty_text}")
                     return
 
-        test_doc = CTestDocumentation(name, docstring, filter(lambda p: p != name and p != "NAME", params))
+        test_doc = CTestDocumentation(name, docstring, [p for p in params if p != name and p != "NAME"])
         self.documented.append(test_doc)
         self.documented_awaiting_function_def = test_doc
+
+    def process_option(self, ctx: CMakeParser.Command_invocationContext, docstring: str):
+        """
+        Extracts information from an :code:`option()` command and creates
+        an OptionDocumentation from it. It extracts the option name,
+        the help text, and the default value if any.
+
+        :param ctx: Documented command context. Constructed by the Antlr4 parser.
+        :param docstring: Cleaned docstring.
+        """
+        params = [param.getText() for param in ctx.single_argument()]  # Extract parameters
+        if len(params) < 2 or len(params) > 3:
+            pretty_text = docstring
+            pretty_text += f"\n{ctx.getText()}"
+
+            self.logger.error(
+                f"ct_add_section() called with incorrect parameters: {params}\n\n{pretty_text}")
+            return
+        option_doc = OptionDocumentation(
+            params[0],
+            docstring,
+            "bool",
+            params[1],
+            params[2] if len(params) == 3 else None
+        )
+        self.documented.append(option_doc)
 
     def process_generic_command(self, command_name: str, ctx: CMakeParser.Command_invocationContext, docstring: str):
         """

--- a/src/cminx/aggregator.py
+++ b/src/cminx/aggregator.py
@@ -460,8 +460,8 @@ class DocumentationAggregator(CMakeListener):
             params[0],
             docstring,
             "bool",
-            params[1],
-            params[2] if len(params) == 3 else None
+            params[2] if len(params) == 3 else None,
+            params[1]
         )
         self.documented.append(option_doc)
 

--- a/src/cminx/config.py
+++ b/src/cminx/config.py
@@ -36,6 +36,7 @@ def config_template(output_dir_relative_to_config: bool = False) -> dict:
             "include_undocumented_ct_add_test": bool,
             "include_undocumented_add_test": bool,
             "include_undocumented_ct_add_section": bool,
+            "include_undocumented_option": bool,
             "auto_exclude_directories_without_cmake": bool,
             "kwargs_doc_trigger_string": confuse.Optional(confuse.String(), default=":keyword"),
             "exclude_filters": confuse.Optional(list, default=()),
@@ -71,6 +72,7 @@ class InputSettings:
     include_undocumented_ct_add_test: bool = True
     include_undocumented_ct_add_section: bool = True
     include_undocumented_add_test: bool = True
+    include_undocumented_option: bool = True
     auto_exclude_directories_without_cmake: bool = True
     kwargs_doc_trigger_string: str = ":param **kwargs:"
     exclude_filters: List[str] = ()

--- a/src/cminx/config_default.yaml
+++ b/src/cminx/config_default.yaml
@@ -45,6 +45,10 @@ input:
   # auto-generated.
   include_undocumented_ct_add_section: true
 
+  # Whether undocumented options should have documentation
+  # auto-generated.
+  include_undocumented_option: true
+
   # Whether undocumented CTest tests should have documentation
   # auto-generated. This controls whether all vanilla
   # CMake add_test() commands should be documented,

--- a/src/cminx/documentation_types.py
+++ b/src/cminx/documentation_types.py
@@ -163,8 +163,8 @@ class OptionDocumentation(VariableDocumentation):
     specifying the variable is an option.
     """
 
-    help_text: Union[str, None]
-    """The help text that the option has, if any"""
+    help_text: str
+    """The help text that the option has."""
 
     def process(self, writer: RSTWriter):
         d = writer.directive("data", f"{self.name}")

--- a/src/cminx/documentation_types.py
+++ b/src/cminx/documentation_types.py
@@ -174,10 +174,10 @@ class OptionDocumentation(VariableDocumentation):
             This variable is a user-editable option,
             meaning it appears within the cache and can be
             edited on the command line by the :code:`-D` flag.
-            Help text: {self.help_text} 
             """)
         d.text(self.doc)
-        d.field("Default value", self.value)
+        d.field("Help text", self.help_text)
+        d.field("Default value", self.value if self.value is not None else "OFF")
         d.field("type", self.type)
 
 

--- a/src/cminx/documentation_types.py
+++ b/src/cminx/documentation_types.py
@@ -132,7 +132,7 @@ class VariableDocumentation(DocumentationType):
     and a :code:`type` field.
     """
 
-    type: VarType
+    type: Union[VarType, str]
     """The type that the variable is."""
 
     value: Union[str, None]
@@ -151,6 +151,34 @@ class VariableDocumentation(DocumentationType):
         else:
             raise ValueError(f"Unknown variable type: {self.type}")
         d.field("type", var_type)
+
+
+@dataclass
+class OptionDocumentation(VariableDocumentation):
+    """
+    This class documents a CMake option() command,
+    representing a user-configurable option that can
+    be selected via the cache. The RST form of this documentation
+    also uses the :code:`data` directive, but includes a note
+    specifying the variable is an option.
+    """
+
+    help_text: Union[str, None]
+    """The help text that the option has, if any"""
+
+    def process(self, writer: RSTWriter):
+        d = writer.directive("data", f"{self.name}")
+        note = d.directive("note")
+        note.text(
+            f"""
+            This variable is a user-editable option,
+            meaning it appears within the cache and can be
+            edited on the command line by the :code:`-D` flag.
+            Help text: {self.help_text} 
+            """)
+        d.text(self.doc)
+        d.field("Default value", self.value)
+        d.field("type", self.type)
 
 
 @dataclass

--- a/tests/examples/example.cmake
+++ b/tests/examples/example.cmake
@@ -286,3 +286,8 @@ add_test(
     COMMAND bash -c echo test
 )
 
+#[[[
+# This is a documented option
+#]]
+option(TEST_OPTION "This is a test option" OFF)
+

--- a/tests/examples/sphinx/source/example.rst
+++ b/tests/examples/sphinx/source/example.rst
@@ -339,3 +339,24 @@ examples.example
 
    
 
+
+.. data:: TEST_OPTION
+
+
+   .. note:: 
+
+      
+                  This variable is a user-editable option,
+                  meaning it appears within the cache and can be
+                  edited on the command line by the :code:`-D` flag.
+                  
+
+   This is a documented option
+   
+
+   :Help text: "This is a test option"
+
+   :Default value: OFF
+
+   :type: bool
+

--- a/tests/examples/sphinx/source/example_no_undocumented.rst
+++ b/tests/examples/sphinx/source/example_no_undocumented.rst
@@ -139,3 +139,24 @@ examples.example
    command
    
 
+
+.. data:: TEST_OPTION
+
+
+   .. note:: 
+
+      
+                  This variable is a user-editable option,
+                  meaning it appears within the cache and can be
+                  edited on the command line by the :code:`-D` flag.
+                  
+
+   This is a documented option
+   
+
+   :Help text: "This is a test option"
+
+   :Default value: OFF
+
+   :type: bool
+

--- a/tests/examples/sphinx/source/example_no_undocumented_diff_header.rst
+++ b/tests/examples/sphinx/source/example_no_undocumented_diff_header.rst
@@ -139,3 +139,24 @@ examples.example.cmake
    command
    
 
+
+.. data:: TEST_OPTION
+
+
+   .. note:: 
+
+      
+                  This variable is a user-editable option,
+                  meaning it appears within the cache and can be
+                  edited on the command line by the :code:`-D` flag.
+                  
+
+   This is a documented option
+   
+
+   :Help text: "This is a test option"
+
+   :Default value: OFF
+
+   :type: bool
+

--- a/tests/examples/sphinx/source/example_prefix.rst
+++ b/tests/examples/sphinx/source/example_prefix.rst
@@ -339,3 +339,24 @@ prefix.example
 
    
 
+
+.. data:: TEST_OPTION
+
+
+   .. note:: 
+
+      
+                  This variable is a user-editable option,
+                  meaning it appears within the cache and can be
+                  edited on the command line by the :code:`-D` flag.
+                  
+
+   This is a documented option
+   
+
+   :Help text: "This is a test option"
+
+   :Default value: OFF
+
+   :type: bool
+

--- a/tests/test_samples/corr_rst/option.rst
+++ b/tests/test_samples/corr_rst/option.rst
@@ -1,0 +1,28 @@
+
+###################
+test_samples.option
+###################
+
+.. module:: test_samples.option
+
+
+.. data:: TEST_OPTION
+
+
+   .. note:: 
+
+      
+                  This variable is a user-editable option,
+                  meaning it appears within the cache and can be
+                  edited on the command line by the :code:`-D` flag.
+                  
+
+   This is a documentation of an option.
+   
+
+   :Help text: "This is a user-accessible option"
+
+   :Default value: OFF
+
+   :type: bool
+

--- a/tests/test_samples/corr_rst/undocumented_option_no_default.rst
+++ b/tests/test_samples/corr_rst/undocumented_option_no_default.rst
@@ -1,0 +1,27 @@
+
+###########################################
+test_samples.undocumented_option_no_default
+###########################################
+
+.. module:: test_samples.undocumented_option_no_default
+
+
+.. data:: "UNDOCUMENTED_OPTION_NO_DEFAULT"
+
+
+   .. note:: 
+
+      
+                  This variable is a user-editable option,
+                  meaning it appears within the cache and can be
+                  edited on the command line by the :code:`-D` flag.
+                  
+
+   
+
+   :Help text: "This is an undocumented option and it doesn't have a default value"
+
+   :Default value: OFF
+
+   :type: bool
+

--- a/tests/test_samples/option.cmake
+++ b/tests/test_samples/option.cmake
@@ -1,0 +1,5 @@
+
+#[[[
+# This is a documentation of an option.
+#]]
+option(TEST_OPTION "This is a user-accessible option" OFF)

--- a/tests/test_samples/undocumented_option_no_default.cmake
+++ b/tests/test_samples/undocumented_option_no_default.cmake
@@ -1,0 +1,3 @@
+
+
+option("UNDOCUMENTED_OPTION_NO_DEFAULT" "This is an undocumented option and it doesn't have a default value")

--- a/tests/unit_tests/test_aggregator.py
+++ b/tests/unit_tests/test_aggregator.py
@@ -364,6 +364,16 @@ cpp_end_class()
         self.assertEqual(0, len(self.aggregator.documented),
                          f"Incorrect {command_name}() call was still added to documented list: {self.aggregator.documented}")
 
+    def test_incorrect_option_params(self):
+        params = []
+        command_name = "option"
+        command = f'{command_name}({" ".join(params)})'
+        docstring = f"This is documentation for an incorrect {command_name}() call"
+        self.input_stream = InputStream(f'#[[[\n{docstring}\n#]]\n{command}')
+        self.reset()
+        self.assertEqual(0, len(self.aggregator.documented),
+                         f"Incorrect {command_name}() call was still added to documented list: {self.aggregator.documented}")
+
     def test_cpp_attr_outside_class(self):
         self.input_stream = InputStream("#[[[\n# cpp_attr() outside class\n#]]\ncpp_attr()")
         self.reset()


### PR DESCRIPTION
**Is this pull request associated with an issue(s)?**
Fixes #139 

**Description**
This PR adds support for documenting CMAke `option()` commands. It also adds a new configuration option for documenting undocumented options.

**TODOs**

- [x] Add tests with options intermingled with other documented commands
