### PR TITLE
Fix accidentally copied ct_add_test code in add_test processor code

### DIFF
--- a/src/cminx/aggregator.py
+++ b/src/cminx/aggregator.py
@@ -434,9 +434,8 @@ class DocumentationAggregator(CMakeListener):
                     self.logger.error(f"add_test() called with incorrect parameters: {params}\n\n{pretty_text}")
                     return
 
-        test_doc = CTestDocumentation(name, docstring, filter(lambda p: p != name and p != "NAME", params))
+        test_doc = CTestDocumentation(name, docstring, [p for p in params if p != name and p != "NAME"])
         self.documented.append(test_doc)
-        self.documented_awaiting_function_def = test_doc
 
     def process_generic_command(self, command_name: str, ctx: CMakeParser.Command_invocationContext, docstring: str):
         """

--- a/tests/test_samples/add_test_and_func_after.cmake
+++ b/tests/test_samples/add_test_and_func_after.cmake
@@ -1,0 +1,11 @@
+#[[[
+# This is a CTest test
+#]]
+add_test(NAME anyname)
+
+
+#[[[
+# This is a function with two parameters.
+#]]
+function(myfunc paramA paramB)
+endfunction()

--- a/tests/test_samples/corr_rst/add_test_and_func_after.rst
+++ b/tests/test_samples/corr_rst/add_test_and_func_after.rst
@@ -1,0 +1,22 @@
+
+####################################
+test_samples.add_test_and_func_after
+####################################
+
+.. module:: test_samples.add_test_and_func_after
+
+
+.. function:: anyname()
+
+
+   .. warning:: This is a CTest test definition, do not call this manually. Use the "ctest" program to execute this test.
+
+   This is a CTest test
+   
+
+
+.. function:: myfunc(paramA paramB)
+
+   This is a function with two parameters.
+   
+


### PR DESCRIPTION
**Is this pull request associated with an issue(s)?**
Fixes #143 

**Description**
This PR removes a section of accidentally-copied code, replaces a filter call with a list-comprehension,
and adds a test to ensure the issue doesn't occur again.
