### PR TITLE
Fix ValueError on Python 3.11

### DIFF
--- a/.github/workflows/pip_install.yaml
+++ b/.github/workflows/pip_install.yaml
@@ -28,7 +28,7 @@ jobs:
 
     strategy:
       matrix:
-        python_version: ['3.8.13', '3.9.13', '3.10.5']
+        python_version: ['3.8.13', '3.9.13', '3.10.5', '3.11.2']
 
     steps:
       - uses: actions/checkout@v2

--- a/src/cminx/config.py
+++ b/src/cminx/config.py
@@ -100,10 +100,10 @@ class RSTSettings:
 
 @dataclass
 class Settings:
-    input: InputSettings = InputSettings()
-    output: OutputSettings = OutputSettings()
-    logging: LoggingSettings = LoggingSettings()
-    rst: RSTSettings = RSTSettings()
+    input: InputSettings = field(default_factory=lambda: InputSettings())
+    output: OutputSettings = field(default_factory=lambda: OutputSettings())
+    logging: LoggingSettings = field(default_factory=lambda: LoggingSettings())
+    rst: RSTSettings = field(default_factory=lambda: RSTSettings())
 
 
 def dict_to_settings(input_dict: dict) -> Settings:


### PR DESCRIPTION
**Is this pull request associated with an issue(s)?**
Fixes #142 

**Description**
This PR turns the component settings objects into default factory fields instead of static singletons, correcting a ValueError on Python 3.11. It also adds Python 3.11.2 to the test matrix of the `pip_install` action.
