### PR TITLE
Make a PyPI release on every push to master

### DIFF
--- a/.github/workflows/tag_and_release.yaml
+++ b/.github/workflows/tag_and_release.yaml
@@ -26,9 +26,6 @@ jobs:
       token: ${{ secrets.UPDATE_VERSION_TXT }}
   release:
     needs: tag
-    if: | 
-      (needs.tag.outputs.bumped_major == 'true') || 
-      (needs.tag.outputs.bumped_minor == 'true')
     uses: CMakePP/.github/.github/workflows/pypi_release_master.yaml@main
     secrets:
       token: ${{ secrets.PYPI_API_TOKEN }}


### PR DESCRIPTION
**Is this pull request associated with an issue(s)?**
Hopefully fixes #138 temporarily

**Description**
This change should allow the release action to run while
we continue to investigate why it isn't running currently.

This is meant to be a temporary change just to get PyPI releases working
in the meantime.