### PR TITLE
Update tag_and_release.yaml

### DIFF
--- a/.github/workflows/tag_and_release.yaml
+++ b/.github/workflows/tag_and_release.yaml
@@ -23,7 +23,7 @@ jobs:
   tag:
     uses: CMakePP/.github/.github/workflows/tag_and_release_master.yaml@main
     secrets:
-      token: ${{ secrets.UPDATE_VERSION_TXT }}
+      token: ${{ secrets.GITHUB_TOKEN }}
   release:
     needs: tag
     uses: CMakePP/.github/.github/workflows/pypi_release_master.yaml@main


### PR DESCRIPTION
Replaces our custom token with the default GITHUB_TOKEN
