### PR TITLE
Parse set() options correctly

### DIFF
--- a/src/cminx/aggregator.py
+++ b/src/cminx/aggregator.py
@@ -24,10 +24,11 @@ aggregates them in a single list.
 :Author: Branden Butler
 :License: Apache 2.0
 """
-
+import itertools
 import logging
 import re
 from dataclasses import dataclass
+from enum import Enum
 from typing import List, Union
 
 from antlr4 import ParserRuleContext
@@ -43,6 +44,20 @@ from .parser.CMakeListener import CMakeListener
 # inconsistencies here
 from .parser.CMakeParser import CMakeParser
 from cminx import Settings
+
+
+class SetCommandKeywords(Enum):
+    CACHE = "CACHE"
+    PARENT_SCOPE = "PARENT_SCOPE"
+    BOOL = "BOOL"
+    PATH = "PATH"
+    STRING = "STRING"
+    INTERNAL = "INTERNAL"
+    FORCE = "FORCE"
+
+    @classmethod
+    def values(cls):
+        return [param.value for param in cls]
 
 
 @dataclass
@@ -283,7 +298,7 @@ class DocumentationAggregator(CMakeListener):
 
         :param docstring: Cleaned docstring.
         """
-
+        params = [val.getText() for val in ctx.single_argument()]
         if len(ctx.single_argument()) < 1:
             pretty_text = docstring
             pretty_text += f"\n{ctx.getText()}"
@@ -292,17 +307,22 @@ class DocumentationAggregator(CMakeListener):
                 f"set() called with incorrect parameters: {ctx.single_argument()}\n\n{pretty_text}")
             return
 
-        varname = ctx.single_argument()[
-            0].getText()
-        # First argument is name of variable so ignore that
-        arg_len = len(ctx.single_argument()) - 1
+        varname = params[0]
+        # Used for comparing against the set() command's keywords
+        params_upper = [param.upper() for param in params[1:]]
+        values = list(
+            itertools.takewhile(
+                lambda param: param not in SetCommandKeywords.values(),
+                params[1:]
+            )
+        )
 
-        if arg_len > 1:  # List
-            values = [val.getText()
-                      for val in ctx.single_argument()[1:]]
+        keywords = {kw: kw in params_upper for kw in SetCommandKeywords.values()}
+
+        if len(values) > 1:  # List
             self.documented.append(VariableDocumentation(
-                varname, docstring, VarType.LIST, " ".join(values)))
-        elif arg_len == 1:  # String
+                varname, docstring, VarType.LIST, " ".join(values), keywords))
+        elif len(values) == 1:  # String
             value = ctx.single_argument()[1].getText()
 
             # If the value includes the quote marks,
@@ -312,10 +332,10 @@ class DocumentationAggregator(CMakeListener):
             if value[-1] == '"':
                 value = value[:-1]
             self.documented.append(VariableDocumentation(
-                varname, docstring, VarType.STRING, value))
+                varname, docstring, VarType.STRING, value, keywords))
         else:  # Unset
             self.documented.append(VariableDocumentation(
-                varname, docstring, VarType.UNSET, None))
+                varname, docstring, VarType.UNSET, None, keywords))
 
     def process_cpp_class(self, ctx: CMakeParser.Command_invocationContext, docstring: str) -> None:
         """
@@ -500,6 +520,7 @@ class DocumentationAggregator(CMakeListener):
             docstring,
             "bool",
             params[2] if len(params) == 3 else None,
+            {},
             params[1]
         )
         self.documented.append(option_doc)

--- a/src/cminx/documentation_types.py
+++ b/src/cminx/documentation_types.py
@@ -27,7 +27,7 @@ import textwrap
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
 from enum import Enum
-from typing import Union, List
+from typing import Union, List, Dict
 
 from .rstwriter import RSTWriter, Directive, interpreted_text
 
@@ -144,6 +144,12 @@ class VariableDocumentation(DocumentationType):
 
     value: Union[str, None]
     """A default value that the variable has"""
+
+    keywords: Dict[str, bool]
+    """
+    A dictionary between the set() command keywords and whether
+    they were present / active in the documented call.
+    """
 
     def process(self, writer: RSTWriter) -> None:
         d = writer.directive("data", f"{self.name}")

--- a/tests/unit_tests/test_documenter.py
+++ b/tests/unit_tests/test_documenter.py
@@ -74,7 +74,7 @@ class TestDocumenter(unittest.TestCase):
                 self.fail(f"Unknown documentation type: {doc}")
 
     def test_incorrect_variable_type(self):
-        var_doc = VariableDocumentation("name", "Not a valid variable type", "0", "This should fail")
+        var_doc = VariableDocumentation("name", "Not a valid variable type", "0", "This should fail", {})
         self.assertRaises(ValueError, var_doc.process,
                           RSTWriter("test_writer"))
 


### PR DESCRIPTION
**Is this pull request associated with an issue(s)?**
Fixes #155 

**Description**
This PR completely redesigns the `set()` command processor. It parses the parameters to the call according to <https://cmake.org/cmake/help/latest/command/set.html>. Notes are generated for certain options like `PARENT_SCOPE` or `CACHE`.

**TODOs**

- [ ] Generate notes for parsed options
- [ ] Add tests for many different variations of set()
- [ ] Probably refactor the option() processor
